### PR TITLE
Fix datach alias to use docker attach

### DIFF
--- a/.emacs.d/eshell/alias
+++ b/.emacs.d/eshell/alias
@@ -83,7 +83,7 @@ alias ddel docker rmi -f
 alias dda docker rmi -f $(docker images -q)
 alias dd docker rmi -f
 alias dc docker commit $(docker ps -l -q)
-alias datach docker start $1 ; docker atach $1
+alias datach docker start $1 ; docker attach $1
 alias docker sudo docker
 alias d rm -fr $*
 alias cs (modify-coding-system-alist processsjis-dos)

--- a/.zsh.d/function/init-docker--util
+++ b/.zsh.d/function/init-docker--util
@@ -109,7 +109,7 @@ dsshd() {
 
 datach() {
   docker start $1
-  docker atach $1
+  docker attach $1
 }
 
 denv() {


### PR DESCRIPTION
## Summary
- call `docker attach` from the `datach` function
- use `docker attach` in the Emacs alias

## Testing
- `command -v shellcheck` *(fails: no output)*
