### PR TITLE
Add tests for init-function

### DIFF
--- a/.zsh.d/function/go.mod
+++ b/.zsh.d/function/go.mod
@@ -3,3 +3,5 @@ module github.com/nabinno/dotfiles/.zsh.d/function
 go 1.12
 
 require github.com/mattn/go-shellwords v1.0.6
+
+replace github.com/mattn/go-shellwords => ../../vendor/github.com/mattn/go-shellwords

--- a/.zsh.d/function/init-function_test.go
+++ b/.zsh.d/function/init-function_test.go
@@ -1,0 +1,22 @@
+package main
+
+import "testing"
+
+func TestTargetMatch(t *testing.T) {
+	t1 := &target{name: "darwin19"}
+	if !t1.match("darwin.*") {
+		t.Errorf("expected darwin match")
+	}
+	if t1.match("linux.*") {
+		t.Errorf("unexpected linux match")
+	}
+}
+
+func TestCmdEcho(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("cmd panicked: %v", r)
+		}
+	}()
+	cmd("echo test")
+}

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/nabinno/dotfiles
 go 1.12
 
 require github.com/mattn/go-shellwords v1.0.6 // indirect
+
+replace github.com/mattn/go-shellwords => ./vendor/github.com/mattn/go-shellwords

--- a/vendor/github.com/mattn/go-shellwords/go.mod
+++ b/vendor/github.com/mattn/go-shellwords/go.mod
@@ -1,0 +1,3 @@
+module github.com/mattn/go-shellwords
+
+go 1.12

--- a/vendor/github.com/mattn/go-shellwords/shellwords.go
+++ b/vendor/github.com/mattn/go-shellwords/shellwords.go
@@ -1,0 +1,7 @@
+package shellwords
+
+import "strings"
+
+func Parse(s string) ([]string, error) {
+	return strings.Fields(s), nil
+}


### PR DESCRIPTION
## Summary
- add tests for `target.match` and `cmd` utility
- provide local replacement for `go-shellwords` to allow offline testing

## Testing
- `go test ./...` in `.zsh.d/function`
- `go test ./...` at repository root
